### PR TITLE
feat: Live Analytics Dashboard with Dynamic Charts and KPI Filtering

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -30,7 +30,7 @@ class AnalyticsController extends Controller
     {
         try {
             $year  = (int) $request->get('year',  now()->year);
-            $month = (int) $request->get('month', now()->month);
+            $month = max(1, min(12, (int) $request->get('month', now()->month)));
 
             $totalCollection = DB::table('vw_acct_receivable')
                 ->whereYear('ar_date', $year)
@@ -134,7 +134,9 @@ class AnalyticsController extends Controller
             }
 
             Log::info('[Analytics] Monthly Trend', [
-                'range'    => $labels[0] . ' → ' . $labels[11],
+                'range' => $labels[0] . ' → ' . $labels[11],
+            ]);
+            Log::debug('[Analytics] Monthly Trend data', [
                 'income'   => $income,
                 'expenses' => $expenses,
             ]);

--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+class AnalyticsController extends Controller
+{
+    private const DEVELOPER_LOTS = [
+        'CRESCENT',
+        'PRIMEWATER INFRASTRUCTURE CORP. (P1)',
+        'SYMMETRICAL VENTURES, INC.',
+        'CROWN ASIA PROPERTIES, INC.',
+        'PS BANK (CROWN ASIA PROPERTIES, INC)',
+        'FLORA P. CAVILES',
+        'LAND BANK OF THE PHILS.',
+    ];
+
+    public function index()
+    {
+        return view('analytics.dashboard', [
+            'developerLots' => self::DEVELOPER_LOTS,
+        ]);
+    }
+
+    public function getKpis(Request $request)
+    {
+        try {
+            $year  = (int) $request->get('year',  now()->year);
+            $month = (int) $request->get('month', now()->month);
+
+            $totalCollection = DB::table('vw_acct_receivable')
+                ->whereYear('ar_date', $year)
+                ->whereMonth('ar_date', $month)
+                ->where('ar_amount', '>', 0)
+                ->sum('ar_amount');
+
+            $expenseSub = DB::table('vw_acct_payable')
+                ->whereYear('ap_date', $year)
+                ->whereMonth('ap_date', $month)
+                ->select('ap_voucherno', DB::raw('MAX(ap_total) as voucher_total'))
+                ->groupBy('ap_voucherno');
+
+            $totalExpenses = DB::query()->fromSub($expenseSub, 't')->sum('voucher_total');
+
+            $activeMembers = DB::table('vw_member_data')
+                ->where('hoa_status', 'ACTIVE')
+                ->whereNotIn('mem_name', self::DEVELOPER_LOTS)
+                ->count();
+
+            $totalLots = DB::table('vw_member_data')
+                ->whereNotIn('mem_name', self::DEVELOPER_LOTS)
+                ->count();
+
+            Log::info('[Analytics] Total Lots', ['total_lots' => $totalLots]);
+
+            $paidLots = DB::table('acct_receivable as ar')
+                ->join('charts_of_account as coa', 'ar.acct_type_id', '=', 'coa.acct_type_id')
+                ->join('vw_member_data as vmd', 'ar.mem_id', '=', 'vmd.mem_id')
+                ->where('coa.acct_description', 'Association Dues')
+                ->whereYear('ar.ar_date', $year)
+                ->whereMonth('ar.ar_date', $month)
+                ->where('ar.ar_amount', '>', 0)
+                ->whereNotIn('vmd.mem_name', self::DEVELOPER_LOTS)
+                ->distinct()
+                ->count('ar.payor_address');
+
+            Log::info('[Analytics] Paid Lots Count', ['paid_lots' => $paidLots, 'month' => $month, 'year' => $year]);
+
+            $collectionRate = $totalLots > 0
+                ? round(($paidLots / $totalLots) * 100, 1)
+                : 0;
+
+            $payload = [
+                'total_collection' => (float) $totalCollection,
+                'total_expenses'   => (float) $totalExpenses,
+                'active_members'   => (int) $activeMembers,
+                'collection_rate'  => $collectionRate,
+            ];
+
+            Log::info('[Analytics] KPIs', array_merge($payload, [
+                'filter_month'               => $month,
+                'filter_year'                => $year,
+                'collection_rate_paid_lots'  => $paidLots,
+                'collection_rate_total_lots' => $totalLots,
+            ]));
+
+            return response()->json($payload);
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Failed to load KPI data'], 500);
+        }
+    }
+
+    public function getMonthlyTrend(Request $request)
+    {
+        try {
+            $mode = $request->get('mode', 'rolling');
+            $year = (int) $request->get('year', now()->year);
+
+            $start = $mode === 'year'
+                ? Carbon::createFromDate($year, 1, 1)->startOfMonth()
+                : Carbon::now()->startOfMonth()->subMonths(11);
+
+            $incomeMap = DB::table('vw_acct_receivable')
+                ->where('ar_amount', '>', 0)
+                ->where('ar_date', '>=', $start->toDateString())
+                ->select(DB::raw("DATE_FORMAT(ar_date, '%Y-%m') as ym"), DB::raw('SUM(ar_amount) as total'))
+                ->groupBy('ym')
+                ->pluck('total', 'ym');
+
+            $expenseSub = DB::table('vw_acct_payable')
+                ->where('ap_date', '>=', $start->toDateString())
+                ->select('ap_voucherno', DB::raw("DATE_FORMAT(ap_date, '%Y-%m') as ym"), DB::raw('MAX(ap_total) as voucher_total'))
+                ->groupBy('ap_voucherno', 'ym');
+
+            $expenseMap = DB::query()->fromSub($expenseSub, 't')
+                ->select('ym', DB::raw('SUM(voucher_total) as total'))
+                ->groupBy('ym')
+                ->pluck('total', 'ym');
+
+            $labels   = [];
+            $income   = [];
+            $expenses = [];
+
+            for ($i = 0; $i < 12; $i++) {
+                $month  = $start->copy()->addMonths($i);
+                $ym     = $month->format('Y-m');
+                $labels[]   = $month->format('M Y');
+                $income[]   = (float) ($incomeMap[$ym] ?? 0);
+                $expenses[] = (float) ($expenseMap[$ym] ?? 0);
+            }
+
+            Log::info('[Analytics] Monthly Trend', [
+                'range'    => $labels[0] . ' → ' . $labels[11],
+                'income'   => $income,
+                'expenses' => $expenses,
+            ]);
+
+            return response()->json(compact('labels', 'income', 'expenses'));
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Failed to load monthly trend data'], 500);
+        }
+    }
+
+    public function getArrearAging()
+    {
+        try {
+            $rows = DB::table('vw_member_data')
+                ->where('hoa_status', 'DELINQUENT')
+                ->whereNotIn('mem_name', self::DEVELOPER_LOTS)
+                ->select(DB::raw('
+                    SUM(CASE WHEN arrear_count BETWEEN 3 AND 6  THEN 1 ELSE 0 END) as b1,
+                    SUM(CASE WHEN arrear_count BETWEEN 7 AND 12 THEN 1 ELSE 0 END) as b2,
+                    SUM(CASE WHEN arrear_count BETWEEN 13 AND 24 THEN 1 ELSE 0 END) as b3,
+                    SUM(CASE WHEN arrear_count > 24             THEN 1 ELSE 0 END) as b4
+                '))
+                ->first();
+
+            $counts = [
+                (int) $rows->b1,
+                (int) $rows->b2,
+                (int) $rows->b3,
+                (int) $rows->b4,
+            ];
+
+            $total = array_sum($counts);
+
+            $labels = ['3–6 months', '7–12 months', '13–24 months', '24+ months'];
+
+            $buckets = [];
+            foreach ($counts as $i => $count) {
+                $buckets[] = [
+                    'label'   => $labels[$i],
+                    'count'   => $count,
+                    'percent' => $total > 0 ? round(($count / $total) * 100, 1) : 0,
+                ];
+            }
+
+            Log::info('[Analytics] Arrear Aging', [
+                'total_delinquent' => $total,
+                'buckets'          => $buckets,
+            ]);
+
+            return response()->json([
+                'buckets'          => $buckets,
+                'total_delinquent' => $total,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Failed to load arrear aging data'], 500);
+        }
+    }
+
+    public function getPermitStats()
+    {
+        try {
+            $stats = DB::table('vw_construction_permit')
+                ->select(DB::raw('`Permit Status` as label'), DB::raw('COUNT(*) as count'))
+                ->groupBy('Permit Status')
+                ->orderByDesc('count')
+                ->get()
+                ->map(fn($row) => ['label' => $row->label, 'count' => (int) $row->count])
+                ->values();
+
+            $total = $stats->sum('count');
+
+            Log::info('[Analytics] Permit Stats', [
+                'total' => (int) $total,
+                'stats' => $stats->toArray(),
+            ]);
+
+            return response()->json([
+                'stats' => $stats,
+                'total' => (int) $total,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json(['error' => 'Failed to load permit stats'], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -101,8 +101,8 @@ class LoginController extends Controller
             // Determine redirect based on user role
             $user = auth()->user();
             $redirect = $user->role == 4
-                ? route('reports.extraction')  // Report role goes to Data Extraction
-                : route('dashboard');          // All other roles go to Dashboard
+                ? route('reports.extraction')    // Report role goes to Data Extraction
+                : route('analytics.dashboard');  // All other roles go to Analytics
 
             return response()->json([
                 'success' => true,

--- a/public/assets/css/analytics.css
+++ b/public/assets/css/analytics.css
@@ -1,0 +1,338 @@
+/* =========================================================
+   FHOA Analytics Dashboard — Scoped to .analytics-page
+   Aesthetic: Fintech Precision (cobalt + gold + cream)
+   Typography: Sora (headings) + IBM Plex Sans (body)
+   ========================================================= */
+
+.analytics-page {
+    --analytics-cobalt:       #1E4D8C;
+    --analytics-cobalt-light: #4A7DC4;
+    --analytics-cobalt-faint: #EBF1F9;
+    --analytics-gold:         #C9923A;
+    --analytics-gold-faint:   #FAF3E8;
+    --analytics-green:        #2E7D52;
+    --analytics-green-faint:  #E8F4EE;
+    --analytics-red:          #C0392B;
+    --analytics-red-faint:    #FAEAE8;
+    --analytics-amber:        #E8A87C;
+    --analytics-bg:           #F5F3EE;
+    --analytics-card-bg:      #FFFFFF;
+    --analytics-border:       #E8E3DA;
+    --analytics-text:         #1C1C1C;
+    --analytics-muted:        #7A7368;
+    --analytics-shadow:       0 2px 14px rgba(44, 30, 10, 0.07);
+    --analytics-shadow-hover: 0 6px 24px rgba(44, 30, 10, 0.12);
+    --analytics-radius:       10px;
+    --font-heading:           'Sora', 'Segoe UI', system-ui, sans-serif;
+    --font-body:              'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif;
+
+    background-color: var(--analytics-bg);
+    font-family: var(--font-body);
+    color: var(--analytics-text);
+}
+
+/* ─── Page Header ─────────────────────────────────────────── */
+
+.analytics-page-header {
+    margin-bottom: 1.75rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--analytics-border);
+}
+
+.analytics-title {
+    font-family: var(--font-heading);
+    font-size: 1.65rem;
+    font-weight: 700;
+    color: var(--analytics-cobalt);
+    margin: 0 0 0.2rem 0;
+    letter-spacing: -0.03em;
+    line-height: 1.2;
+}
+
+.analytics-subtitle {
+    font-size: 0.82rem;
+    color: var(--analytics-muted);
+    margin: 0;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+/* ─── Entrance Animation ──────────────────────────────────── */
+
+@keyframes analyticsReveal {
+    from {
+        opacity: 0;
+        transform: translateY(14px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.kpi-card-col {
+    animation: analyticsReveal 0.45s ease both;
+}
+
+.analytics-card-wrap {
+    animation: analyticsReveal 0.5s ease both;
+}
+
+/* ─── KPI Cards ───────────────────────────────────────────── */
+
+.kpi-card {
+    background: var(--analytics-card-bg);
+    border-radius: var(--analytics-radius);
+    border-left: 4px solid var(--analytics-gold);
+    box-shadow: var(--analytics-shadow);
+    padding: 1.25rem 1.4rem 1.1rem;
+    height: 100%;
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.kpi-card::after {
+    content: '';
+    position: absolute;
+    top: -20px;
+    right: -20px;
+    width: 80px;
+    height: 80px;
+    background: var(--analytics-gold-faint);
+    border-radius: 50%;
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.kpi-card:hover {
+    box-shadow: var(--analytics-shadow-hover);
+    transform: translateY(-2px);
+}
+
+.kpi-card-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--analytics-muted);
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+.kpi-card-value {
+    font-family: var(--font-heading);
+    font-size: 1.85rem;
+    font-weight: 700;
+    color: var(--analytics-cobalt);
+    line-height: 1.1;
+    letter-spacing: -0.04em;
+    margin-bottom: 0.45rem;
+}
+
+.kpi-card-delta {
+    font-size: 0.78rem;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+}
+
+.kpi-card-delta.positive {
+    color: var(--analytics-green);
+}
+
+.kpi-card-delta.negative {
+    color: var(--analytics-red);
+}
+
+.kpi-card-delta.neutral {
+    color: var(--analytics-muted);
+}
+
+/* ─── Analytics Cards (chart containers) ─────────────────── */
+
+.analytics-card {
+    background: var(--analytics-card-bg);
+    border-radius: var(--analytics-radius);
+    box-shadow: var(--analytics-shadow);
+    padding: 1.25rem 1.4rem 1rem;
+    height: 100%;
+    border: 1px solid var(--analytics-border);
+    transition: box-shadow 0.2s ease;
+}
+
+.analytics-card:hover {
+    box-shadow: var(--analytics-shadow-hover);
+}
+
+.analytics-card-header {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.6rem;
+    border-bottom: 1px solid var(--analytics-border);
+}
+
+.analytics-card-title {
+    font-family: var(--font-heading);
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--analytics-cobalt);
+    margin: 0 0 0.1rem 0;
+    letter-spacing: -0.02em;
+}
+
+.analytics-card-subtitle {
+    font-size: 0.72rem;
+    color: var(--analytics-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 500;
+}
+
+/* ─── Arrear Aging Bars ───────────────────────────────────── */
+
+.aging-section {
+    margin-top: 0.25rem;
+}
+
+.aging-row {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0.9rem;
+    gap: 0.75rem;
+}
+
+.aging-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--analytics-text);
+    white-space: nowrap;
+    min-width: 90px;
+}
+
+.aging-count-badge {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--analytics-text);
+    white-space: nowrap;
+    min-width: 60px;
+    text-align: right;
+}
+
+.aging-bar-track {
+    flex: 1;
+    background: #EAE6DF;
+    border-radius: 4px;
+    height: 20px;
+    overflow: hidden;
+}
+
+.aging-bar {
+    height: 100%;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    padding-left: 8px;
+    transition: width 0.6s ease;
+    min-width: 24px;
+}
+
+.aging-bar-text {
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: white;
+    white-space: nowrap;
+}
+
+/* ─── Permit Info Panel ───────────────────────────────────── */
+
+.permit-stat-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.permit-stat-list li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.65rem 0;
+    border-bottom: 1px solid var(--analytics-border);
+    gap: 0.75rem;
+}
+
+.permit-stat-list li:last-child {
+    border-bottom: none;
+}
+
+.permit-stat-label {
+    font-size: 0.83rem;
+    color: var(--analytics-text);
+    font-weight: 500;
+}
+
+.permit-stat-value {
+    font-family: var(--font-heading);
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--analytics-cobalt);
+}
+
+/* ─── Custom Badge Variants ───────────────────────────────── */
+
+.badge-cobalt {
+    background-color: var(--analytics-cobalt);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.3em 0.65em;
+    border-radius: 20px;
+}
+
+.badge-gold {
+    background-color: var(--analytics-gold);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.3em 0.65em;
+    border-radius: 20px;
+}
+
+.badge-green {
+    background-color: var(--analytics-green);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.3em 0.65em;
+    border-radius: 20px;
+}
+
+/* ─── Row spacing helpers ─────────────────────────────────── */
+
+.analytics-section {
+    margin-bottom: 1.25rem;
+}
+
+/* ─── Responsive ──────────────────────────────────────────── */
+
+@media (max-width: 992px) {
+    .kpi-card-value {
+        font-size: 1.6rem;
+    }
+
+    .analytics-title {
+        font-size: 1.6rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .aging-label {
+        min-width: 70px;
+        font-size: 0.72rem;
+    }
+
+    .kpi-card {
+        padding: 1rem 1.1rem 0.9rem;
+    }
+}

--- a/public/assets/css/analytics.css
+++ b/public/assets/css/analytics.css
@@ -26,7 +26,7 @@
     --font-heading:           'Sora', 'Segoe UI', system-ui, sans-serif;
     --font-body:              'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif;
 
-    background-color: var(--analytics-bg);
+    /* background-color: var(--analytics-bg); */
     font-family: var(--font-body);
     color: var(--analytics-text);
 }
@@ -95,13 +95,13 @@
 .kpi-card::after {
     content: '';
     position: absolute;
-    top: -20px;
-    right: -20px;
+    top: -35px;
+    right: -35px;
     width: 80px;
     height: 80px;
     background: var(--analytics-gold-faint);
     border-radius: 50%;
-    opacity: 0.6;
+    opacity: 0.7;
     pointer-events: none;
 }
 

--- a/resources/views/analytics/dashboard.blade.php
+++ b/resources/views/analytics/dashboard.blade.php
@@ -359,14 +359,30 @@ document.addEventListener('DOMContentLoaded', function () {
             if (!ul) return;
             ul.innerHTML = '';
             data.stats.forEach(s => {
-                const li = document.createElement('li');
-                li.innerHTML = '<span class="permit-stat-label">' + s.label + '</span>'
-                             + '<span class="permit-stat-value">' + s.count + '</span>';
+                const li    = document.createElement('li');
+                const label = document.createElement('span');
+                const value = document.createElement('span');
+                label.className   = 'permit-stat-label';
+                value.className   = 'permit-stat-value';
+                label.textContent = s.label;
+                value.textContent = s.count;
+                li.appendChild(label);
+                li.appendChild(value);
                 ul.appendChild(li);
             });
-            const totalLi = document.createElement('li');
-            totalLi.innerHTML = '<span class="permit-stat-label"><strong>Total</strong></span>'
-                              + '<span class="permit-stat-value"><strong>' + data.total + '</strong></span>';
+            const totalLi    = document.createElement('li');
+            const totalLabel = document.createElement('span');
+            const totalValue = document.createElement('span');
+            const bold1      = document.createElement('strong');
+            const bold2      = document.createElement('strong');
+            totalLabel.className = 'permit-stat-label';
+            totalValue.className = 'permit-stat-value';
+            bold1.textContent    = 'Total';
+            bold2.textContent    = data.total;
+            totalLabel.appendChild(bold1);
+            totalValue.appendChild(bold2);
+            totalLi.appendChild(totalLabel);
+            totalLi.appendChild(totalValue);
             ul.appendChild(totalLi);
         })
         .catch(() => console.error('Permit stats fetch failed'));

--- a/resources/views/analytics/dashboard.blade.php
+++ b/resources/views/analytics/dashboard.blade.php
@@ -19,7 +19,28 @@
     {{-- ── Page Header ──────────────────────────────────────── --}}
     <div class="analytics-page-header">
         <h2 class="analytics-title">Financial Analytics</h2>
-        <p class="analytics-subtitle">Year-to-date performance overview &middot; FY 2025 &middot; Fortezza HOA</p>
+        <p class="analytics-subtitle">Current month performance overview &middot; Fortezza HOA</p>
+        <p class="analytics-subtitle" style="margin-top: 0.25rem; font-size: 0.6rem; color: #7A7368;">
+            <i class="bi bi-info-circle me-1"></i>
+            Developer lots are excluded from all figures in this dashboard:
+            {{ implode(', ', $developerLots) }}.
+        </p>
+    </div>
+
+    {{-- ── KPI Filter Bar ───────────────────────────────────── --}}
+    <div class="d-flex align-items-center gap-2 mb-3 flex-wrap" id="kpi-filter-bar">
+        <span style="font-size:0.82rem;font-weight:600;color:#7A7368;letter-spacing:0.03em;">FILTER PERIOD</span>
+        <select id="filter-month" class="form-select form-select-sm" style="width:auto;">
+            <option value="1">January</option><option value="2">February</option>
+            <option value="3">March</option><option value="4">April</option>
+            <option value="5">May</option><option value="6">June</option>
+            <option value="7">July</option><option value="8">August</option>
+            <option value="9">September</option><option value="10">October</option>
+            <option value="11">November</option><option value="12">December</option>
+        </select>
+        <select id="filter-year" class="form-select form-select-sm" style="width:auto;"></select>
+        <button id="filter-reset" class="btn btn-sm btn-outline-secondary">This Month</button>
+        <small class="text-muted fst-italic">Active Members is always current and unaffected.</small>
     </div>
 
     {{-- ── KPI Cards ────────────────────────────────────────── --}}
@@ -27,97 +48,61 @@
 
         <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.05s">
             <div class="kpi-card">
-                <div class="kpi-card-label">Total Collections YTD</div>
-                <div class="kpi-card-value">&#8369;1,284,500</div>
-                <div class="kpi-card-delta positive">
-                    <i class="bi bi-arrow-up-short"></i> 12.4% vs last year
-                </div>
+                <div class="kpi-card-label" id="label-collection">Total Collection (This Month)</div>
+                <div class="kpi-card-value" id="kpi-collection">—</div>
             </div>
         </div>
 
         <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.15s">
             <div class="kpi-card" style="border-left-color: #C0392B;">
-                <div class="kpi-card-label">Outstanding Arrears</div>
-                <div class="kpi-card-value">&#8369;387,250</div>
-                <div class="kpi-card-delta negative">
-                    <i class="bi bi-people"></i> 75 members affected
-                </div>
+                <div class="kpi-card-label" id="label-expenses">Total Expenses (This Month)</div>
+                <div class="kpi-card-value" id="kpi-expenses">—</div>
             </div>
         </div>
 
         <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.25s">
             <div class="kpi-card" style="border-left-color: #2E7D52;">
-                <div class="kpi-card-label">Collection Rate (This Month)</div>
-                <div class="kpi-card-value">87%</div>
-                <div class="kpi-card-delta positive">
-                    <i class="bi bi-arrow-up-short"></i> 4% vs last month
-                </div>
+                <div class="kpi-card-label" id="label-collection-rate">Monthly Dues Collection Rate (This Month)</div>
+                <div class="kpi-card-value" id="kpi-collection-rate">—</div>
             </div>
         </div>
 
         <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.35s">
             <div class="kpi-card" style="border-left-color: #1E4D8C;">
                 <div class="kpi-card-label">Active Members</div>
-                <div class="kpi-card-value">412</div>
-                <div class="kpi-card-delta neutral">
-                    <i class="bi bi-people"></i> of 487 total members
-                </div>
+                <div class="kpi-card-value" id="kpi-active-members">—</div>
             </div>
         </div>
 
     </div>
 
-    {{-- ── Row 1: Monthly Collections + Member Status ───────── --}}
+    {{-- ── Row 1: Monthly Trend Chart ──────────────────────── --}}
     <div class="row g-3 analytics-section">
 
-        <div class="col-lg-8 analytics-card-wrap" style="animation-delay: 0.1s">
+        <div class="col-12 analytics-card-wrap" style="animation-delay: 0.1s">
             <div class="analytics-card">
                 <div class="analytics-card-header">
-                    <span class="analytics-card-title">Monthly Collections</span>
-                    <span class="analytics-card-subtitle">Jan &ndash; Dec 2025 &middot; Philippine Peso (&#8369;)</span>
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                        <span class="analytics-card-title">Income vs. Expenses</span>
+                        <div class="d-flex align-items-center gap-2">
+                            <div class="btn-group btn-group-sm" role="group">
+                                <button type="button" class="btn btn-primary active" id="mode-rolling">Last 12 Months</button>
+                                <button type="button" class="btn btn-outline-primary" id="mode-year">Calendar Year</button>
+                            </div>
+                            <select id="chart-year-picker" class="form-select form-select-sm" style="width:auto; display:none;"></select>
+                        </div>
+                    </div>
+                    <span class="analytics-card-subtitle" id="chart-subtitle">Last 12 months &middot; Philippine Peso (&#8369;)</span>
                 </div>
-                <div id="monthlyCollectionsChart"></div>
-            </div>
-        </div>
-
-        <div class="col-lg-4 analytics-card-wrap" style="animation-delay: 0.2s">
-            <div class="analytics-card">
-                <div class="analytics-card-header">
-                    <span class="analytics-card-title">Member Status</span>
-                    <span class="analytics-card-subtitle">Current standing &middot; 487 total</span>
+                <div id="chart-container" style="position:relative;">
+                    <canvas id="monthly-trend-chart"></canvas>
                 </div>
-                <div id="memberStatusChart"></div>
-            </div>
-        </div>
-
-    </div>
-
-    {{-- ── Row 2: Collection Rate Trend + Payment Method ────── --}}
-    <div class="row g-3 analytics-section">
-
-        <div class="col-lg-8 analytics-card-wrap" style="animation-delay: 0.15s">
-            <div class="analytics-card">
-                <div class="analytics-card-header">
-                    <span class="analytics-card-title">Collection Rate Trend</span>
-                    <span class="analytics-card-subtitle">Jan &ndash; Dec 2025 &middot; Percentage (%)</span>
-                </div>
-                <div id="collectionRateTrendChart"></div>
-            </div>
-        </div>
-
-        <div class="col-lg-4 analytics-card-wrap" style="animation-delay: 0.25s">
-            <div class="analytics-card">
-                <div class="analytics-card-header">
-                    <span class="analytics-card-title">Payment Method Split</span>
-                    <span class="analytics-card-subtitle">YTD breakdown</span>
-                </div>
-                <div id="paymentMethodChart"></div>
             </div>
         </div>
 
     </div>
 
-    {{-- ── Row 3: Arrear Aging + Permit Info ────────────────── --}}
+    {{-- ── Row 2: Arrear Aging + Permit Info ────────────────── --}}
     <div class="row g-3 analytics-section">
 
         {{-- Arrear Aging --}}
@@ -130,48 +115,48 @@
                 <div class="aging-section">
 
                     <div class="aging-row">
-                        <div class="aging-label">1 – 3 months</div>
+                        <div class="aging-label">3–6 months</div>
+                        <div class="aging-count-badge" id="aging-count-1">—</div>
                         <div class="aging-bar-track">
-                            <div class="aging-bar" style="width: 100%; background: #E8A87C;">
-                                <span class="aging-bar-text">38 members</span>
+                            <div class="aging-bar" id="aging-bar-1" style="width: 0%;">
+                                <span class="aging-bar-text" id="aging-pct-1"></span>
                             </div>
                         </div>
-                        <div class="aging-count-badge">38</div>
                     </div>
 
                     <div class="aging-row">
-                        <div class="aging-label">4 – 6 months</div>
+                        <div class="aging-label">7–12 months</div>
+                        <div class="aging-count-badge" id="aging-count-2">—</div>
                         <div class="aging-bar-track">
-                            <div class="aging-bar" style="width: 58%; background: #C9923A;">
-                                <span class="aging-bar-text">22 members</span>
+                            <div class="aging-bar" id="aging-bar-2" style="width: 0%;">
+                                <span class="aging-bar-text" id="aging-pct-2"></span>
                             </div>
                         </div>
-                        <div class="aging-count-badge">22</div>
                     </div>
 
                     <div class="aging-row">
-                        <div class="aging-label">7 – 12 months</div>
+                        <div class="aging-label">13–24 months</div>
+                        <div class="aging-count-badge" id="aging-count-3">—</div>
                         <div class="aging-bar-track">
-                            <div class="aging-bar" style="width: 29%; background: #C0582B;">
-                                <span class="aging-bar-text">11</span>
+                            <div class="aging-bar" id="aging-bar-3" style="width: 0%;">
+                                <span class="aging-bar-text" id="aging-pct-3"></span>
                             </div>
                         </div>
-                        <div class="aging-count-badge">11</div>
                     </div>
 
                     <div class="aging-row">
-                        <div class="aging-label">12+ months</div>
+                        <div class="aging-label">24+ months</div>
+                        <div class="aging-count-badge" id="aging-count-4">—</div>
                         <div class="aging-bar-track">
-                            <div class="aging-bar" style="width: 11%; background: #C0392B; min-width: 32px;">
-                                <span class="aging-bar-text">4</span>
+                            <div class="aging-bar" id="aging-bar-4" style="width: 0%;">
+                                <span class="aging-bar-text" id="aging-pct-4"></span>
                             </div>
                         </div>
-                        <div class="aging-count-badge">4</div>
                     </div>
 
                     <div style="margin-top: 0.75rem; padding-top: 0.6rem; border-top: 1px solid #E8E3DA; display: flex; justify-content: space-between; align-items: center;">
                         <span style="font-size: 0.78rem; color: #7A7368; font-weight: 500;">Total delinquent</span>
-                        <span style="font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.1rem; font-weight: 700; color: #C0392B;">75 members</span>
+                        <span id="aging-total" style="font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.1rem; font-weight: 700; color: #C0392B;">—</span>
                     </div>
                 </div>
             </div>
@@ -182,33 +167,10 @@
             <div class="analytics-card">
                 <div class="analytics-card-header">
                     <span class="analytics-card-title">Construction Permits</span>
-                    <span class="analytics-card-subtitle">Current status &middot; YTD summary</span>
+                    <span class="analytics-card-subtitle">Current status breakdown</span>
                 </div>
-                <ul class="permit-stat-list">
-                    <li>
-                        <span class="permit-stat-label">Active Permits</span>
-                        <span class="badge-cobalt">12</span>
-                    </li>
-                    <li>
-                        <span class="permit-stat-label">Pending Approval</span>
-                        <span class="badge-gold">5</span>
-                    </li>
-                    <li>
-                        <span class="permit-stat-label">Completed (YTD)</span>
-                        <span class="badge-green">28</span>
-                    </li>
-                    <li>
-                        <span class="permit-stat-label">Bonds Currently Held</span>
-                        <span class="permit-stat-value">&#8369;340,000</span>
-                    </li>
-                    <li>
-                        <span class="permit-stat-label">Bonds Released (YTD)</span>
-                        <span class="permit-stat-value">&#8369;185,000</span>
-                    </li>
-                    <li>
-                        <span class="permit-stat-label">Permit Fee Revenue (YTD)</span>
-                        <span class="permit-stat-value">&#8369;62,500</span>
-                    </li>
+                <ul class="permit-stat-list" id="permit-stat-list">
+                    <li><span class="permit-stat-label" style="color: #7A7368;">Loading…</span></li>
                 </ul>
             </div>
         </div>
@@ -219,243 +181,195 @@
 @endsection
 
 @push('scripts')
-<script src="https://cdn.jsdelivr.net/npm/apexcharts@3.54.0/dist/apexcharts.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.2.0/dist/chartjs-plugin-datalabels.min.js"></script>
 <script>
+Chart.register(ChartDataLabels);
 document.addEventListener('DOMContentLoaded', function () {
 
-    const PALETTE = {
-        cobalt:      '#1E4D8C',
-        cobaltLight: '#4A7DC4',
-        gold:        '#C9923A',
-        green:       '#2E7D52',
-        red:         '#C0392B',
-        amber:       '#E8A87C',
-        muted:       '#7A7368',
-        gridLine:    '#EAE6DF'
-    };
+    const fmt     = (n) => '₱' + parseFloat(n || 0).toLocaleString('en-PH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+    const setText = (id, val) => { const el = document.getElementById(id); if (el) el.textContent = val; };
+    const now     = new Date();
+    const currentYear = now.getFullYear();
 
-    const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    // --- Populate year dropdowns (current year going back 5 years) ---
+    const yearRange = Array.from({ length: 6 }, (_, i) => currentYear - i);
+    ['filter-year', 'chart-year-picker'].forEach(id => {
+        const sel = document.getElementById(id);
+        if (!sel) return;
+        yearRange.forEach(y => {
+            const opt = document.createElement('option');
+            opt.value = y;
+            opt.textContent = y;
+            if (y === currentYear) opt.selected = true;
+            sel.appendChild(opt);
+        });
+    });
 
-    function baseOptions() {
-        return {
-            chart: {
-                fontFamily: "'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif",
-                toolbar:    { show: false },
-                animations: { enabled: true, easing: 'easeinout', speed: 700 }
-            },
-            grid: {
-                borderColor:    PALETTE.gridLine,
-                strokeDashArray: 4,
-                padding:        { left: 4, right: 4 }
-            },
-            tooltip: { theme: 'light' }
-        };
+    // Set filter-month default to current month
+    const filterMonth = document.getElementById('filter-month');
+    const filterYear  = document.getElementById('filter-year');
+    if (filterMonth) filterMonth.value = now.getMonth() + 1;
+
+    // ── KPI Loader ────────────────────────────────────────────
+    const MONTH_NAMES = ['January','February','March','April','May','June',
+                         'July','August','September','October','November','December'];
+
+    function loadKpis(month, year) {
+        const period = MONTH_NAMES[month - 1] + ' ' + year;
+        setText('label-collection',      'Total Collection (' + period + ')');
+        setText('label-expenses',        'Total Expenses (' + period + ')');
+        setText('label-collection-rate', 'Monthly Dues Collection Rate (' + period + ')');
+
+        fetch('/analytics/data/kpis?month=' + month + '&year=' + year)
+            .then(r => r.json())
+            .then(data => {
+                setText('kpi-collection',      fmt(data.total_collection));
+                setText('kpi-expenses',        fmt(data.total_expenses));
+                setText('kpi-active-members',  data.active_members);
+                setText('kpi-collection-rate', data.collection_rate + '%');
+            })
+            .catch(() => console.error('KPI fetch failed'));
     }
 
-    // ── Chart 1: Monthly Collections Bar ──────────────────────
-    (function () {
-        const opts = Object.assign({}, baseOptions(), {
-            chart: Object.assign({}, baseOptions().chart, {
-                type:   'bar',
-                height: 270
-            }),
-            series: [{
-                name: 'Collections (₱)',
-                data: [98000, 92000, 88000, 105000, 110000, 107000, 115000, 103000, 108000, 122000, 130000, 106500]
-            }],
-            xaxis: {
-                categories: MONTHS,
-                labels: {
-                    style: { fontSize: '11px', colors: PALETTE.muted }
-                },
-                axisBorder: { show: false },
-                axisTicks:  { show: false }
-            },
-            yaxis: {
-                labels: {
-                    formatter: v => '₱' + (v / 1000).toFixed(0) + 'k',
-                    style: { fontSize: '11px', colors: PALETTE.muted }
+    filterMonth?.addEventListener('change', () => loadKpis(filterMonth.value, filterYear.value));
+    filterYear?.addEventListener('change',  () => loadKpis(filterMonth.value, filterYear.value));
+    document.getElementById('filter-reset')?.addEventListener('click', () => {
+        filterMonth.value = now.getMonth() + 1;
+        filterYear.value  = currentYear;
+        loadKpis(filterMonth.value, filterYear.value);
+    });
+
+    loadKpis(now.getMonth() + 1, currentYear); // initial load
+
+    // ── Chart Loader ──────────────────────────────────────────
+    let trendChart = null;
+
+    function loadTrendChart(mode, year) {
+        fetch('/analytics/data/monthly-trend?mode=' + mode + '&year=' + year)
+            .then(r => r.json())
+            .then(data => {
+                if (trendChart) { trendChart.destroy(); trendChart = null; }
+                const ctx = document.getElementById('monthly-trend-chart');
+                if (!ctx) return;
+
+                // In calendar-year mode for the current year, hide future months
+                let labels   = data.labels;
+                let income   = data.income;
+                let expenses = data.expenses;
+                if (mode === 'year' && parseInt(year) === currentYear) {
+                    const upTo = now.getMonth() + 1; // 1-based, inclusive
+                    labels   = labels.slice(0, upTo);
+                    income   = income.slice(0, upTo);
+                    expenses = expenses.slice(0, upTo);
                 }
-            },
-            plotOptions: {
-                bar: {
-                    columnWidth: '52%',
-                    borderRadius: 4,
-                    dataLabels: { position: 'top' }
-                }
-            },
-            dataLabels: { enabled: false },
-            fill: { colors: [PALETTE.cobalt] },
-            colors: [PALETTE.cobalt],
-            states: {
-                hover: { filter: { type: 'lighten', value: 0.1 } }
-            },
-            tooltip: {
-                theme: 'light',
-                y: { formatter: v => '₱' + v.toLocaleString() }
-            }
-        });
 
-        new ApexCharts(document.querySelector('#monthlyCollectionsChart'), opts).render();
-    })();
+                const HEIGHT_PER_MONTH = 48; // px per month (covers 2 bars + gap)
+                const CHART_OVERHEAD   =70; // legend + x-axis + padding
+                document.getElementById('chart-container').style.height =
+                    (labels.length * HEIGHT_PER_MONTH + CHART_OVERHEAD) + 'px';
 
-    // ── Chart 2: Member Status Donut ───────────────────────────
-    (function () {
-        const total  = 487;
-        const active = 412;
-        const delinq = 75;
-
-        const opts = Object.assign({}, baseOptions(), {
-            chart: Object.assign({}, baseOptions().chart, {
-                type:   'donut',
-                height: 270
-            }),
-            series: [active, delinq],
-            labels: ['Active', 'Delinquent'],
-            colors: [PALETTE.green, PALETTE.red],
-            plotOptions: {
-                pie: {
-                    donut: {
-                        size: '66%',
-                        labels: {
-                            show: true,
-                            total: {
-                                show:      true,
-                                label:     'Total',
-                                formatter: () => total
+                trendChart = new Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels: labels,
+                        datasets: [
+                            { label: 'Income',   data: income,   backgroundColor: '#1E4D8C', borderRadius: 4 },
+                            { label: 'Expenses', data: expenses, backgroundColor: '#C9923A', borderRadius: 4 }
+                        ]
+                    },
+                    options: {
+                        indexAxis: 'y',
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            legend: { position: 'top' },
+                            datalabels: {
+                                anchor: 'end',
+                                align: 'end',
+                                color: '#7A7368',
+                                font: { size: 11 },
+                                formatter: (value) => {
+                                    if (!value) return '';
+                                    if (value >= 1000000) return '₱' + (value / 1000000).toFixed(1) + 'M';
+                                    return '₱' + Math.round(value / 1000) + 'k';
+                                }
                             }
-                        }
+                        },
+                        scales: {
+                            x: { ticks: { callback: (v) => '₱' + v.toLocaleString('en-PH') } }
+                        },
+                        layout: { padding: { right: 48 } }
                     }
-                }
-            },
-            dataLabels: { enabled: false },
-            legend: {
-                position: 'bottom',
-                fontSize:  '12px',
-                formatter: (label, opts) => {
-                    const val = opts.w.globals.series[opts.seriesIndex];
-                    const pct = ((val / total) * 100).toFixed(1);
-                    return `${label}: ${val} (${pct}%)`;
-                }
-            },
-            tooltip: {
-                y: {
-                    formatter: v => v + ' members (' + ((v / total) * 100).toFixed(1) + '%)'
-                }
-            }
-        });
+                });
+                const subtitle = document.getElementById('chart-subtitle');
+                if (subtitle) subtitle.textContent = mode === 'year'
+                    ? 'Jan – Dec ' + year + ' · Philippine Peso (₱)'
+                    : 'Last 12 months · Philippine Peso (₱)';
+            })
+            .catch(() => console.error('Monthly trend fetch failed'));
+    }
 
-        new ApexCharts(document.querySelector('#memberStatusChart'), opts).render();
-    })();
+    // Toggle button logic
+    const modeRollingBtn  = document.getElementById('mode-rolling');
+    const modeYearBtn     = document.getElementById('mode-year');
+    const chartYearPicker = document.getElementById('chart-year-picker');
 
-    // ── Chart 3: Collection Rate Trend Area ────────────────────
-    (function () {
-        const opts = Object.assign({}, baseOptions(), {
-            chart: Object.assign({}, baseOptions().chart, {
-                type:   'area',
-                height: 270
-            }),
-            series: [{
-                name: 'Collection Rate',
-                data: [82, 78, 71, 80, 85, 83, 88, 84, 86, 90, 91, 87]
-            }],
-            xaxis: {
-                categories: MONTHS,
-                labels: {
-                    style: { fontSize: '11px', colors: PALETTE.muted }
-                },
-                axisBorder: { show: false },
-                axisTicks:  { show: false }
-            },
-            yaxis: {
-                min: 60,
-                max: 100,
-                labels: {
-                    formatter: v => v + '%',
-                    style: { fontSize: '11px', colors: PALETTE.muted }
-                }
-            },
-            stroke: {
-                curve: 'smooth',
-                width: 2.5,
-                colors: [PALETTE.cobalt]
-            },
-            fill: {
-                type: 'gradient',
-                gradient: {
-                    shadeIntensity: 1,
-                    opacityFrom:    0.35,
-                    opacityTo:      0.02,
-                    stops:          [0, 95, 100],
-                    colorStops: [{
-                        offset: 0,
-                        color:  PALETTE.cobalt,
-                        opacity: 0.35
-                    }, {
-                        offset: 100,
-                        color:  PALETTE.cobalt,
-                        opacity: 0.02
-                    }]
-                }
-            },
-            colors: [PALETTE.cobalt],
-            markers: {
-                size: 3,
-                colors: [PALETTE.cobalt],
-                strokeWidth: 2,
-                strokeColors: '#fff',
-                hover: { size: 5 }
-            },
-            dataLabels: { enabled: false },
-            tooltip: {
-                theme: 'light',
-                y: { formatter: v => v + '%' }
-            }
-        });
+    function activateMode(mode) {
+        const isYear = mode === 'year';
+        modeYearBtn.classList.toggle('active',              isYear);
+        modeYearBtn.classList.toggle('btn-primary',         isYear);
+        modeYearBtn.classList.toggle('btn-outline-primary', !isYear);
+        modeRollingBtn.classList.toggle('active',              !isYear);
+        modeRollingBtn.classList.toggle('btn-primary',         !isYear);
+        modeRollingBtn.classList.toggle('btn-outline-primary',  isYear);
+        chartYearPicker.style.display = isYear ? '' : 'none';
+        loadTrendChart(mode, chartYearPicker.value);
+    }
 
-        new ApexCharts(document.querySelector('#collectionRateTrendChart'), opts).render();
-    })();
+    modeRollingBtn?.addEventListener('click',  () => activateMode('rolling'));
+    modeYearBtn?.addEventListener('click',     () => activateMode('year'));
+    chartYearPicker?.addEventListener('change', () => loadTrendChart('year', chartYearPicker.value));
 
-    // ── Chart 4: Payment Method Donut ──────────────────────────
-    (function () {
-        const opts = Object.assign({}, baseOptions(), {
-            chart: Object.assign({}, baseOptions().chart, {
-                type:   'donut',
-                height: 270
-            }),
-            series: [44, 28, 18, 10],
-            labels: ['GCash', 'Cash', 'Bank Transfer', 'Check'],
-            colors: [PALETTE.cobalt, PALETTE.gold, PALETTE.green, PALETTE.muted],
-            plotOptions: {
-                pie: {
-                    donut: {
-                        size: '66%',
-                        labels: {
-                            show: true,
-                            total: {
-                                show:      true,
-                                label:     'Methods',
-                                formatter: () => '4'
-                            }
-                        }
-                    }
-                }
-            },
-            dataLabels: { enabled: false },
-            legend: {
-                position: 'bottom',
-                fontSize:  '12px',
-                formatter: (label, opts) => {
-                    return label + ': ' + opts.w.globals.series[opts.seriesIndex] + '%';
-                }
-            },
-            tooltip: {
-                y: { formatter: v => v + '% of collections' }
-            }
-        });
+    loadTrendChart('rolling', currentYear); // initial load
 
-        new ApexCharts(document.querySelector('#paymentMethodChart'), opts).render();
-    })();
+    // ── Arrear Aging (no filter — always current snapshot) ────
+    const agingColors = ['#2E7D52', '#C9923A', '#E8A87C', '#C0392B'];
+
+    fetch('/analytics/data/arrear-aging')
+        .then(r => r.json())
+        .then(data => {
+            data.buckets.forEach((bucket, i) => {
+                const n = i + 1;
+                setText('aging-count-' + n, bucket.count + ' members');
+                setText('aging-pct-'   + n, bucket.percent + '%');
+                const bar = document.getElementById('aging-bar-' + n);
+                if (bar) { bar.style.width = bucket.percent + '%'; bar.style.background = agingColors[i]; }
+            });
+            const totalEl = document.getElementById('aging-total');
+            if (totalEl) totalEl.textContent = data.total_delinquent + ' members';
+        })
+        .catch(() => console.error('Arrear aging fetch failed'));
+
+    // ── Permit Stats ──────────────────────────────────────────
+    fetch('/analytics/data/permit-stats')
+        .then(r => r.json())
+        .then(data => {
+            const ul = document.getElementById('permit-stat-list');
+            if (!ul) return;
+            ul.innerHTML = '';
+            data.stats.forEach(s => {
+                const li = document.createElement('li');
+                li.innerHTML = '<span class="permit-stat-label">' + s.label + '</span>'
+                             + '<span class="permit-stat-value">' + s.count + '</span>';
+                ul.appendChild(li);
+            });
+            const totalLi = document.createElement('li');
+            totalLi.innerHTML = '<span class="permit-stat-label"><strong>Total</strong></span>'
+                              + '<span class="permit-stat-value"><strong>' + data.total + '</strong></span>';
+            ul.appendChild(totalLi);
+        })
+        .catch(() => console.error('Permit stats fetch failed'));
 
 });
 </script>

--- a/resources/views/analytics/dashboard.blade.php
+++ b/resources/views/analytics/dashboard.blade.php
@@ -1,0 +1,462 @@
+@extends('layouts.app')
+@section('title', 'Analytics Dashboard — FHOA')
+
+@section('content')
+@php
+    $isNgrok = str_contains(request()->getHost(), 'ngrok');
+@endphp
+
+{{-- Google Fonts: Sora (headings) + IBM Plex Sans (body) --}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+
+{{-- Analytics CSS --}}
+<link rel="stylesheet" href="{{ $isNgrok ? secure_asset('assets/css/analytics.css') : asset('assets/css/analytics.css') }}">
+
+<div class="analytics-page">
+
+    {{-- ── Page Header ──────────────────────────────────────── --}}
+    <div class="analytics-page-header">
+        <h2 class="analytics-title">Financial Analytics</h2>
+        <p class="analytics-subtitle">Year-to-date performance overview &middot; FY 2025 &middot; Fortezza HOA</p>
+    </div>
+
+    {{-- ── KPI Cards ────────────────────────────────────────── --}}
+    <div class="row g-3 analytics-section">
+
+        <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.05s">
+            <div class="kpi-card">
+                <div class="kpi-card-label">Total Collections YTD</div>
+                <div class="kpi-card-value">&#8369;1,284,500</div>
+                <div class="kpi-card-delta positive">
+                    <i class="bi bi-arrow-up-short"></i> 12.4% vs last year
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.15s">
+            <div class="kpi-card" style="border-left-color: #C0392B;">
+                <div class="kpi-card-label">Outstanding Arrears</div>
+                <div class="kpi-card-value">&#8369;387,250</div>
+                <div class="kpi-card-delta negative">
+                    <i class="bi bi-people"></i> 75 members affected
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.25s">
+            <div class="kpi-card" style="border-left-color: #2E7D52;">
+                <div class="kpi-card-label">Collection Rate (This Month)</div>
+                <div class="kpi-card-value">87%</div>
+                <div class="kpi-card-delta positive">
+                    <i class="bi bi-arrow-up-short"></i> 4% vs last month
+                </div>
+            </div>
+        </div>
+
+        <div class="col-sm-6 col-xl-3 kpi-card-col" style="animation-delay: 0.35s">
+            <div class="kpi-card" style="border-left-color: #1E4D8C;">
+                <div class="kpi-card-label">Active Members</div>
+                <div class="kpi-card-value">412</div>
+                <div class="kpi-card-delta neutral">
+                    <i class="bi bi-people"></i> of 487 total members
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    {{-- ── Row 1: Monthly Collections + Member Status ───────── --}}
+    <div class="row g-3 analytics-section">
+
+        <div class="col-lg-8 analytics-card-wrap" style="animation-delay: 0.1s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Monthly Collections</span>
+                    <span class="analytics-card-subtitle">Jan &ndash; Dec 2025 &middot; Philippine Peso (&#8369;)</span>
+                </div>
+                <div id="monthlyCollectionsChart"></div>
+            </div>
+        </div>
+
+        <div class="col-lg-4 analytics-card-wrap" style="animation-delay: 0.2s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Member Status</span>
+                    <span class="analytics-card-subtitle">Current standing &middot; 487 total</span>
+                </div>
+                <div id="memberStatusChart"></div>
+            </div>
+        </div>
+
+    </div>
+
+    {{-- ── Row 2: Collection Rate Trend + Payment Method ────── --}}
+    <div class="row g-3 analytics-section">
+
+        <div class="col-lg-8 analytics-card-wrap" style="animation-delay: 0.15s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Collection Rate Trend</span>
+                    <span class="analytics-card-subtitle">Jan &ndash; Dec 2025 &middot; Percentage (%)</span>
+                </div>
+                <div id="collectionRateTrendChart"></div>
+            </div>
+        </div>
+
+        <div class="col-lg-4 analytics-card-wrap" style="animation-delay: 0.25s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Payment Method Split</span>
+                    <span class="analytics-card-subtitle">YTD breakdown</span>
+                </div>
+                <div id="paymentMethodChart"></div>
+            </div>
+        </div>
+
+    </div>
+
+    {{-- ── Row 3: Arrear Aging + Permit Info ────────────────── --}}
+    <div class="row g-3 analytics-section">
+
+        {{-- Arrear Aging --}}
+        <div class="col-lg-6 analytics-card-wrap" style="animation-delay: 0.2s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Arrear Aging</span>
+                    <span class="analytics-card-subtitle">Delinquent members by months overdue</span>
+                </div>
+                <div class="aging-section">
+
+                    <div class="aging-row">
+                        <div class="aging-label">1 – 3 months</div>
+                        <div class="aging-bar-track">
+                            <div class="aging-bar" style="width: 100%; background: #E8A87C;">
+                                <span class="aging-bar-text">38 members</span>
+                            </div>
+                        </div>
+                        <div class="aging-count-badge">38</div>
+                    </div>
+
+                    <div class="aging-row">
+                        <div class="aging-label">4 – 6 months</div>
+                        <div class="aging-bar-track">
+                            <div class="aging-bar" style="width: 58%; background: #C9923A;">
+                                <span class="aging-bar-text">22 members</span>
+                            </div>
+                        </div>
+                        <div class="aging-count-badge">22</div>
+                    </div>
+
+                    <div class="aging-row">
+                        <div class="aging-label">7 – 12 months</div>
+                        <div class="aging-bar-track">
+                            <div class="aging-bar" style="width: 29%; background: #C0582B;">
+                                <span class="aging-bar-text">11</span>
+                            </div>
+                        </div>
+                        <div class="aging-count-badge">11</div>
+                    </div>
+
+                    <div class="aging-row">
+                        <div class="aging-label">12+ months</div>
+                        <div class="aging-bar-track">
+                            <div class="aging-bar" style="width: 11%; background: #C0392B; min-width: 32px;">
+                                <span class="aging-bar-text">4</span>
+                            </div>
+                        </div>
+                        <div class="aging-count-badge">4</div>
+                    </div>
+
+                    <div style="margin-top: 0.75rem; padding-top: 0.6rem; border-top: 1px solid #E8E3DA; display: flex; justify-content: space-between; align-items: center;">
+                        <span style="font-size: 0.78rem; color: #7A7368; font-weight: 500;">Total delinquent</span>
+                        <span style="font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.1rem; font-weight: 700; color: #C0392B;">75 members</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Construction Permit Info Panel --}}
+        <div class="col-lg-6 analytics-card-wrap" style="animation-delay: 0.3s">
+            <div class="analytics-card">
+                <div class="analytics-card-header">
+                    <span class="analytics-card-title">Construction Permits</span>
+                    <span class="analytics-card-subtitle">Current status &middot; YTD summary</span>
+                </div>
+                <ul class="permit-stat-list">
+                    <li>
+                        <span class="permit-stat-label">Active Permits</span>
+                        <span class="badge-cobalt">12</span>
+                    </li>
+                    <li>
+                        <span class="permit-stat-label">Pending Approval</span>
+                        <span class="badge-gold">5</span>
+                    </li>
+                    <li>
+                        <span class="permit-stat-label">Completed (YTD)</span>
+                        <span class="badge-green">28</span>
+                    </li>
+                    <li>
+                        <span class="permit-stat-label">Bonds Currently Held</span>
+                        <span class="permit-stat-value">&#8369;340,000</span>
+                    </li>
+                    <li>
+                        <span class="permit-stat-label">Bonds Released (YTD)</span>
+                        <span class="permit-stat-value">&#8369;185,000</span>
+                    </li>
+                    <li>
+                        <span class="permit-stat-label">Permit Fee Revenue (YTD)</span>
+                        <span class="permit-stat-value">&#8369;62,500</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+    </div>
+
+</div>{{-- /.analytics-page --}}
+@endsection
+
+@push('scripts')
+<script src="https://cdn.jsdelivr.net/npm/apexcharts@3.54.0/dist/apexcharts.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+
+    const PALETTE = {
+        cobalt:      '#1E4D8C',
+        cobaltLight: '#4A7DC4',
+        gold:        '#C9923A',
+        green:       '#2E7D52',
+        red:         '#C0392B',
+        amber:       '#E8A87C',
+        muted:       '#7A7368',
+        gridLine:    '#EAE6DF'
+    };
+
+    const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+    function baseOptions() {
+        return {
+            chart: {
+                fontFamily: "'IBM Plex Sans', 'Segoe UI', system-ui, sans-serif",
+                toolbar:    { show: false },
+                animations: { enabled: true, easing: 'easeinout', speed: 700 }
+            },
+            grid: {
+                borderColor:    PALETTE.gridLine,
+                strokeDashArray: 4,
+                padding:        { left: 4, right: 4 }
+            },
+            tooltip: { theme: 'light' }
+        };
+    }
+
+    // ── Chart 1: Monthly Collections Bar ──────────────────────
+    (function () {
+        const opts = Object.assign({}, baseOptions(), {
+            chart: Object.assign({}, baseOptions().chart, {
+                type:   'bar',
+                height: 270
+            }),
+            series: [{
+                name: 'Collections (₱)',
+                data: [98000, 92000, 88000, 105000, 110000, 107000, 115000, 103000, 108000, 122000, 130000, 106500]
+            }],
+            xaxis: {
+                categories: MONTHS,
+                labels: {
+                    style: { fontSize: '11px', colors: PALETTE.muted }
+                },
+                axisBorder: { show: false },
+                axisTicks:  { show: false }
+            },
+            yaxis: {
+                labels: {
+                    formatter: v => '₱' + (v / 1000).toFixed(0) + 'k',
+                    style: { fontSize: '11px', colors: PALETTE.muted }
+                }
+            },
+            plotOptions: {
+                bar: {
+                    columnWidth: '52%',
+                    borderRadius: 4,
+                    dataLabels: { position: 'top' }
+                }
+            },
+            dataLabels: { enabled: false },
+            fill: { colors: [PALETTE.cobalt] },
+            colors: [PALETTE.cobalt],
+            states: {
+                hover: { filter: { type: 'lighten', value: 0.1 } }
+            },
+            tooltip: {
+                theme: 'light',
+                y: { formatter: v => '₱' + v.toLocaleString() }
+            }
+        });
+
+        new ApexCharts(document.querySelector('#monthlyCollectionsChart'), opts).render();
+    })();
+
+    // ── Chart 2: Member Status Donut ───────────────────────────
+    (function () {
+        const total  = 487;
+        const active = 412;
+        const delinq = 75;
+
+        const opts = Object.assign({}, baseOptions(), {
+            chart: Object.assign({}, baseOptions().chart, {
+                type:   'donut',
+                height: 270
+            }),
+            series: [active, delinq],
+            labels: ['Active', 'Delinquent'],
+            colors: [PALETTE.green, PALETTE.red],
+            plotOptions: {
+                pie: {
+                    donut: {
+                        size: '66%',
+                        labels: {
+                            show: true,
+                            total: {
+                                show:      true,
+                                label:     'Total',
+                                formatter: () => total
+                            }
+                        }
+                    }
+                }
+            },
+            dataLabels: { enabled: false },
+            legend: {
+                position: 'bottom',
+                fontSize:  '12px',
+                formatter: (label, opts) => {
+                    const val = opts.w.globals.series[opts.seriesIndex];
+                    const pct = ((val / total) * 100).toFixed(1);
+                    return `${label}: ${val} (${pct}%)`;
+                }
+            },
+            tooltip: {
+                y: {
+                    formatter: v => v + ' members (' + ((v / total) * 100).toFixed(1) + '%)'
+                }
+            }
+        });
+
+        new ApexCharts(document.querySelector('#memberStatusChart'), opts).render();
+    })();
+
+    // ── Chart 3: Collection Rate Trend Area ────────────────────
+    (function () {
+        const opts = Object.assign({}, baseOptions(), {
+            chart: Object.assign({}, baseOptions().chart, {
+                type:   'area',
+                height: 270
+            }),
+            series: [{
+                name: 'Collection Rate',
+                data: [82, 78, 71, 80, 85, 83, 88, 84, 86, 90, 91, 87]
+            }],
+            xaxis: {
+                categories: MONTHS,
+                labels: {
+                    style: { fontSize: '11px', colors: PALETTE.muted }
+                },
+                axisBorder: { show: false },
+                axisTicks:  { show: false }
+            },
+            yaxis: {
+                min: 60,
+                max: 100,
+                labels: {
+                    formatter: v => v + '%',
+                    style: { fontSize: '11px', colors: PALETTE.muted }
+                }
+            },
+            stroke: {
+                curve: 'smooth',
+                width: 2.5,
+                colors: [PALETTE.cobalt]
+            },
+            fill: {
+                type: 'gradient',
+                gradient: {
+                    shadeIntensity: 1,
+                    opacityFrom:    0.35,
+                    opacityTo:      0.02,
+                    stops:          [0, 95, 100],
+                    colorStops: [{
+                        offset: 0,
+                        color:  PALETTE.cobalt,
+                        opacity: 0.35
+                    }, {
+                        offset: 100,
+                        color:  PALETTE.cobalt,
+                        opacity: 0.02
+                    }]
+                }
+            },
+            colors: [PALETTE.cobalt],
+            markers: {
+                size: 3,
+                colors: [PALETTE.cobalt],
+                strokeWidth: 2,
+                strokeColors: '#fff',
+                hover: { size: 5 }
+            },
+            dataLabels: { enabled: false },
+            tooltip: {
+                theme: 'light',
+                y: { formatter: v => v + '%' }
+            }
+        });
+
+        new ApexCharts(document.querySelector('#collectionRateTrendChart'), opts).render();
+    })();
+
+    // ── Chart 4: Payment Method Donut ──────────────────────────
+    (function () {
+        const opts = Object.assign({}, baseOptions(), {
+            chart: Object.assign({}, baseOptions().chart, {
+                type:   'donut',
+                height: 270
+            }),
+            series: [44, 28, 18, 10],
+            labels: ['GCash', 'Cash', 'Bank Transfer', 'Check'],
+            colors: [PALETTE.cobalt, PALETTE.gold, PALETTE.green, PALETTE.muted],
+            plotOptions: {
+                pie: {
+                    donut: {
+                        size: '66%',
+                        labels: {
+                            show: true,
+                            total: {
+                                show:      true,
+                                label:     'Methods',
+                                formatter: () => '4'
+                            }
+                        }
+                    }
+                }
+            },
+            dataLabels: { enabled: false },
+            legend: {
+                position: 'bottom',
+                fontSize:  '12px',
+                formatter: (label, opts) => {
+                    return label + ': ' + opts.w.globals.series[opts.seriesIndex] + '%';
+                }
+            },
+            tooltip: {
+                y: { formatter: v => v + '% of collections' }
+            }
+        });
+
+        new ApexCharts(document.querySelector('#paymentMethodChart'), opts).render();
+    })();
+
+});
+</script>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -199,6 +199,12 @@
             $userRole = auth()->user()->role;
         @endphp
 
+        {{-- Analytics Dashboard - All roles can see --}}
+        <a href="{{ route('analytics.dashboard') }}" class="nav-link {{ request()->routeIs('analytics.dashboard') ? 'active' : '' }}">
+            <i class="bi bi-graph-up-arrow"></i>
+            <span>Analytics</span>
+        </a>
+
         {{-- User Management - Admin Only --}}
         @if ($userRole === 1)
             <a href="{{ route('users.users_management') }}" class="nav-link {{ request()->routeIs('users.users_management') ? 'active' : '' }}">
@@ -246,12 +252,6 @@
             <span>Arrear Management</span>
         </a>
         @endif
-
-        {{-- Analytics Dashboard - All roles can see --}}
-        <a href="{{ route('analytics.dashboard') }}" class="nav-link {{ request()->routeIs('analytics.dashboard') ? 'active' : '' }}">
-            <i class="bi bi-graph-up-arrow"></i>
-            <span>Analytics</span>
-        </a>
 
         {{-- Data Extraction - All roles can see --}}
         <a href="{{ route('reports.extraction') }}" class="nav-link {{ request()->routeIs('reports.extraction') ? 'active' : '' }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,6 +14,8 @@
     {{-- <script href="{{ $isNgrok ? secure_asset('assets/jquery/jquery-3.7.1.min.js') : asset('assets/jquery/jquery-3.7.1.min.js') }}"></script>
     <link href="{{ $isNgrok ? secure_asset('assets/select2/css/select2.min.css') : asset('assets/select2/css/select2.min.css') }}" rel="stylesheet"> --}}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+    <link href="{{ $isNgrok ? secure_asset('assets/lib/tabulator/css/tabulator_bootstrap5.min.css') : asset('assets/lib/tabulator/css/tabulator_bootstrap5.min.css') }}" rel="stylesheet">
+    <link href="{{ $isNgrok ? secure_asset('assets/css/tables.css') : asset('assets/css/tables.css') }}" rel="stylesheet">
     <style>
         :root {
             --primary-color: #2c3e50;
@@ -245,6 +247,12 @@
         </a>
         @endif
 
+        {{-- Analytics Dashboard - All roles can see --}}
+        <a href="{{ route('analytics.dashboard') }}" class="nav-link {{ request()->routeIs('analytics.dashboard') ? 'active' : '' }}">
+            <i class="bi bi-graph-up-arrow"></i>
+            <span>Analytics</span>
+        </a>
+
         {{-- Data Extraction - All roles can see --}}
         <a href="{{ route('reports.extraction') }}" class="nav-link {{ request()->routeIs('reports.extraction') ? 'active' : '' }}">
             <i class="bi bi-file-earmark-spreadsheet"></i>
@@ -258,6 +266,8 @@
 
     <script src="{{ $isNgrok ? secure_asset('assets/lib/bootstrap/js/bootstrap.bundle.min.js') : asset('assets/lib/bootstrap/js/bootstrap.bundle.min.js') }}"></script>
     <script src="{{ $isNgrok ? secure_asset('assets/lib/sweetalert2/js/sweetalert2.all.min.js') : asset('assets/lib/sweetalert2/js/sweetalert2.all.min.js') }}"></script>
+    <script src="{{ $isNgrok ? secure_asset('assets/lib/tabulator/js/tabulator.min.js') : asset('assets/lib/tabulator/js/tabulator.min.js') }}"></script>
+    <script src="{{ $isNgrok ? secure_asset('assets/js/tabulator-config.js') : asset('assets/js/tabulator-config.js') }}"></script>
     @stack('scripts')
     
     @if(session('success'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,10 +44,6 @@ Route::middleware(['auth', 'role:1'])->group(function () {
 
 // Routes accessible by Admin, Editor, and Viewer only (Not Report role)
 Route::middleware(['auth', 'role:1,2,3'])->group(function () {
-    // Dashboard
-    Route::get('/', function () {
-        return view('dashboard');
-    })->name('dashboard');
 
     // Residents routes
     Route::prefix('residents')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,11 +10,12 @@ use App\Http\Controllers\ReportExtractionController;
 use App\Http\Controllers\StatementOfAccountController;
 use App\Http\Controllers\ArrearController;
 use App\Http\Controllers\ConstructionPermitController;
+use App\Http\Controllers\AnalyticsController;
 use Illuminate\Support\Facades\Auth;
 
-// Root URL will redirect to dashboard
+// Root URL will redirect to analytics dashboard
 Route::get('/', function () {
-    return redirect()->route('dashboard');
+    return redirect()->route('analytics.dashboard');
 });
 
 // Guest middleware group (unchanged)
@@ -139,9 +140,14 @@ Route::middleware(['auth', 'role:1,2,3,4'])->group(function () {
 // Analytics Dashboard - accessible by ALL authenticated roles
 Route::middleware(['auth', 'role:1,2,3,4'])->group(function () {
     Route::prefix('analytics')->group(function () {
-        Route::get('/dashboard', function () {
-            return view('analytics.dashboard');
-        })->name('analytics.dashboard');
+        Route::get('/dashboard', [AnalyticsController::class, 'index'])->name('analytics.dashboard');
+
+        Route::prefix('data')->name('analytics.data.')->group(function () {
+            Route::get('/kpis',          [AnalyticsController::class, 'getKpis'])->name('kpis');
+            Route::get('/monthly-trend', [AnalyticsController::class, 'getMonthlyTrend'])->name('monthly-trend');
+            Route::get('/arrear-aging',  [AnalyticsController::class, 'getArrearAging'])->name('arrear-aging');
+            Route::get('/permit-stats',  [AnalyticsController::class, 'getPermitStats'])->name('permit-stats');
+        });
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -136,6 +136,15 @@ Route::middleware(['auth', 'role:1,2,3,4'])->group(function () {
     });
 });
 
+// Analytics Dashboard - accessible by ALL authenticated roles
+Route::middleware(['auth', 'role:1,2,3,4'])->group(function () {
+    Route::prefix('analytics')->group(function () {
+        Route::get('/dashboard', function () {
+            return view('analytics.dashboard');
+        })->name('analytics.dashboard');
+    });
+});
+
 // Utility routes accessible without authentication (needed for login page)
 Route::get('/refresh-csrf', function () {
     return response()->json(['token' => csrf_token()]);


### PR DESCRIPTION
## Summary

This PR replaces the static mock-data analytics prototype with a fully live analytics dashboard backed by real database queries. It introduces `AnalyticsController`, four AJAX data endpoints, and a rewritten dashboard blade with interactive filters and dynamic Chart.js visualizations.

---

## What Changed

### New: `AnalyticsController`
- **KPIs** (`/analytics/data/kpis?month=&year=`) — Total Collection, Total Expenses, Active Members, and Monthly Dues Collection Rate for a selected month/year period.
- **Monthly Trend** (`/analytics/data/monthly-trend?mode=&year=`) — Income vs Expenses over Last 12 Months or a selected Calendar Year.
- **Arrear Aging** (`/analytics/data/arrear-aging`) — Delinquent members grouped into 3–6, 7–12, 13–24, and 24+ month buckets.
- **Permit Stats** (`/analytics/data/permit-stats`) — Construction permit count by status, sourced from `vw_construction_permit` (deduplicates by latest revision per permit).

### Developer Lot Exclusion
Seven developer-owned lots are excluded from all KPI, aging, and member figures via a `DEVELOPER_LOTS` constant. An info note listing the excluded names is rendered dynamically on the dashboard from the controller.

### Collection Rate Formula
Collection rate = `COUNT(DISTINCT payor_address)` of Association Dues payments in the selected period ÷ total residential lots. Queries the `acct_receivable` base table directly (joined to `vw_member_data` via `mem_id`) because the view does not expose `mem_id`.

### KPI Filter Bar
Month and year dropdowns filter Total Collection, Total Expenses, and Collection Rate simultaneously. Active Members is always the current snapshot and is unaffected by the filter. Labels update dynamically to show the selected period (e.g. "Total Collection (May 2026)").

### Income vs Expenses Chart
- **Horizontal bar chart** (`indexAxis: 'y'`) for improved readability of peso values.
- **Toggle** between Last 12 Months (rolling) and Calendar Year modes with a year picker.
- **Future month hiding** — in Calendar Year mode for the current year, months beyond today are automatically removed from the chart.
- **`chartjs-plugin-datalabels`** — abbreviated ₱XXk / ₱X.XM labels at bar ends so values are readable without hovering.
- **Dynamic canvas height** — container height computed as `visibleMonths × 48px + 72px`, set on a wrapper `<div>` to avoid Chart.js's responsive resize feedback loop.

### Navigation & Landing Page
- Analytics Dashboard moved to the **top of the sidebar** for all roles.
- Root `/` redirect changed to `analytics.dashboard`.
- Post-login redirect updated: roles 1–3 land on Analytics Dashboard; role 4 (Report) continues to go to Data Extraction.

---

## Files Changed

| File | Change |
|------|--------|
| `app/Http/Controllers/AnalyticsController.php` | **New** — full controller with 4 data endpoints |
| `app/Http/Controllers/Auth/LoginController.php` | Updated post-login redirect for roles 1–3 |
| `resources/views/analytics/dashboard.blade.php` | Full rewrite — live AJAX, filters, horizontal chart |
| `resources/views/layouts/app.blade.php` | Analytics nav link moved to top |
| `routes/web.php` | Root redirect + 4 analytics data routes added |
| `public/assets/css/analytics.css` | Styles for analytics page components |

---

## Testing Checklist

- [ ] `/analytics/dashboard` loads without errors for all roles (1–4)
- [ ] KPI cards show correct totals for current month; filter by month/year updates all three filterable cards
- [ ] "This Month" reset button restores defaults
- [ ] Chart renders horizontally with ₱XXk labels at bar ends
- [ ] Toggle to Calendar Year — future months hidden for current year; past years show all 12 months
- [ ] Last 12 Months mode unaffected by year picker
- [ ] Arrear aging rows show correct bucket counts and percentage bars
- [ ] Construction Permits panel matches the Permits list page totals
- [ ] Developer lot exclusion note lists all 7 names correctly
- [ ] Root `/` redirect lands on Analytics Dashboard (roles 1–3)
- [ ] Role 4 login still redirects to Data Extraction
